### PR TITLE
Bump to 2.84 and update CDN url

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,6 +1,6 @@
 class transmission {
   package { 'transmission':
     provider   => 'appdmg',
-    source => 'http://download.transmissionbt.com/files/Transmission-2.82.dmg'
+    source => 'https://transmission.cachefly.net/Transmission-2.84.dmg'
   }
 }


### PR DESCRIPTION
The current download to 2.82 is broken, because Transmission apparently switched to a new CDN (check https://www.transmissionbt.com/download/ to verify the download link). 

The attached commit updates the download URL that is currently on the Transmission download page. This bumps the version to 2.84 and uses the CDN that is pointed to on the download page.